### PR TITLE
Features/swap token list

### DIFF
--- a/src/arb.ts
+++ b/src/arb.ts
@@ -23,6 +23,7 @@ const addresses: AddressCollection = {
   ammV2: {
     vault: '0xBA12222222228d8Ba445958a75a0704d566BF2C8',
     pools: {
+      genesis: [],
       enabled: [],
       disabled: []
     }

--- a/src/arbTestnet.ts
+++ b/src/arbTestnet.ts
@@ -22,6 +22,7 @@ const addresses: AddressCollection = {
   ammV2: {
     vault: '0x0000000000000000000000000000000000000000',
     pools: {
+      genesis: [],
       enabled: [],
       disabled: []
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,5 +4,6 @@ import rinkeby from './rinkeby'
 import arb from './arb'
 import arbTestnet from './arbTestnet'
 import matic from './matic'
+import lollidao_mainnet from './lollidao.mainnet'
 
-export { mainnet, kovan, rinkeby, arb, arbTestnet, matic }
+export { mainnet, kovan, rinkeby, arb, arbTestnet, matic, lollidao_mainnet }

--- a/src/kovan.ts
+++ b/src/kovan.ts
@@ -1,5 +1,14 @@
 import { AddressCollection } from './types'
 
+const tokens = {
+  WETH: '0x9b1FeAAd523A4f6BA73215C103208907938EA7F1',
+  WBTC: '0x41dE675d148f6acC84E5e88A9515Db0889519d1D',
+  USDC: '0x7e6F38922B59545bB5A6dc3A71039b85dFB1B7cE',
+  fxPHP: '0x07bAB1e2D6DCb965d250F376B811ab8c2373AAE0',
+  XSGD: '0x4DCE1178D2A368397c09fc6C63e2f82F00a2Ca09',
+  EURS: '0xaA64D57E3c781bcFB2e8B1e1C9936C302Db84bCE'
+}
+
 const addresses: AddressCollection = {
   protocol: {
     RNBW: '0x16D185d025bF592114D1A68f83085F36159f6CdA',
@@ -27,12 +36,44 @@ const addresses: AddressCollection = {
   ammV2: {
     vault: '0xBA12222222228d8Ba445958a75a0704d566BF2C8',
     pools: {
-      genesis: [],
-      enabled: [],
+      genesis: [
+        {
+          assets: [tokens.WETH, tokens.USDC],
+          address: '0xe18054c51d10b6162012e8989101e9d762586cac',
+          poolId:
+            '0x3c13bc30b8e878c53fd2a36b679409c073afd75950be43d8858768e956fbc20e'
+        },
+        {
+          assets: [tokens.WBTC, tokens.USDC],
+          address: '0x21ee3b7b61ac1b2bf5b94f2706ab777e51b3dc56',
+          poolId:
+            '0x3c13bc30b8e878c53fd2a36b679409c073afd75950be43d8858768e956fbc20e'
+        }
+      ],
+      enabled: [
+        {
+          assets: [tokens.fxPHP, tokens.USDC],
+          address: '0xca9eC9CF8cBCF7DB2a2d08e43B176bA8d92e381C',
+          poolId:
+            '0xca9ec9cf8cbcf7db2a2d08e43b176ba8d92e381c00010000000000000000071e'
+        },
+        {
+          assets: [tokens.XSGD, tokens.USDC],
+          address: '0x979fc3D80D11D0b58d0E1FFE6a4463cBB813761c',
+          poolId:
+            '0x979fc3d80d11d0b58d0e1ffe6a4463cbb813761c00010000000000000000071f'
+        },
+        {
+          assets: [tokens.EURS, tokens.USDC],
+          address: '0x0A7900dDe4cA3211D3367Cfad739E91b49F46402',
+          poolId:
+            '0x0a7900dde4ca3211d3367cfad739e91b49f46402000100000000000000000720'
+        }
+      ],
       disabled: []
     }
   },
-  tokens: {}
+  tokens
 }
 
 export default addresses

--- a/src/kovan.ts
+++ b/src/kovan.ts
@@ -27,6 +27,7 @@ const addresses: AddressCollection = {
   ammV2: {
     vault: '0xBA12222222228d8Ba445958a75a0704d566BF2C8',
     pools: {
+      genesis: [],
       enabled: [],
       disabled: []
     }

--- a/src/lollidao.mainnet.ts
+++ b/src/lollidao.mainnet.ts
@@ -29,13 +29,13 @@ const addresses: AddressCollection = {
         '0xDf930B5F4F21AE97439d2A211845F499D50A78A0', // XSGD:USDC
         '0xf830ebbab536ca376120565e377fa9cfba9d5a34' // LPHP:USDC
       ],
-      disabled: [
-      ]
+      disabled: []
     }
   },
   ammV2: {
     vault: '0x0000000000000000000000000000000000000000',
     pools: {
+      genesis: [],
       enabled: [],
       disabled: []
     }

--- a/src/mainnet.ts
+++ b/src/mainnet.ts
@@ -37,6 +37,7 @@ const addresses: AddressCollection = {
   ammV2: {
     vault: '0xBA12222222228d8Ba445958a75a0704d566BF2C8',
     pools: {
+      genesis: [],
       enabled: [],
       disabled: []
     }

--- a/src/matic.ts
+++ b/src/matic.ts
@@ -27,6 +27,7 @@ const addresses: AddressCollection = {
   ammV2: {
     vault: '0xBA12222222228d8Ba445958a75a0704d566BF2C8',
     pools: {
+      genesis: [],
       enabled: [],
       disabled: []
     }

--- a/src/rinkeby.ts
+++ b/src/rinkeby.ts
@@ -1,5 +1,14 @@
 import { AddressCollection } from './types'
 
+const tokens = {
+  WETH: '0x8Ac6F66307d1bcFBb4a7b7d4EB86b36b644192Ca',
+  WBTC: '0xf5b0b3b50328B2595BC6a31A526A8A3568CEa42d',
+  USDC: '0x9875C5C44C10e24AEa48C422f819c5c8f933701D',
+  fxPHP: '0x2BFD80c4E72164F62515850cec591D06AB857c65',
+  XSGD: '0x9347839e0257516565C9Dfa03B5756f3401FA237',
+  EURS: '0x8e6d2797DFB73A31d696D7C124C2edDD9932d3e4'
+}
+
 const addresses: AddressCollection = {
   protocol: {
     RNBW: '0x357bdb97FB9555bede5ed5201dBD15a8f3f6B7B8',
@@ -11,16 +20,31 @@ const addresses: AddressCollection = {
   ammV2: {
     vault: '0xBA12222222228d8Ba445958a75a0704d566BF2C8',
     pools: {
+      genesis: [],
       enabled: [
-        '0x4B4404E80bb3Ae9E342B8aC3A95eF014AE7F9E48' // fxPHP:USDC
+        {
+          assets: [tokens.fxPHP, tokens.USDC],
+          address: '0x4B4404E80bb3Ae9E342B8aC3A95eF014AE7F9E48',
+          poolId:
+            '0x4b4404e80bb3ae9e342b8ac3a95ef014ae7f9e480001000000000000000000eb'
+        },
+        {
+          assets: [tokens.XSGD, tokens.USDC],
+          address: '0x30eA140e33E265e3793ce3C125eE72987BDAC50E',
+          poolId:
+            '0x30ea140e33e265e3793ce3c125ee72987bdac50e000100000000000000000178'
+        },
+        {
+          assets: [tokens.EURS, tokens.USDC],
+          address: '0x4159d4279BAc010ef4E4c1a7e085f6103956a95a',
+          poolId:
+            '0x4159d4279bac010ef4e4c1a7e085f6103956a95a000100000000000000000179'
+        }
       ],
       disabled: []
     }
   },
-  tokens: {
-    USDC: '0x9875C5C44C10e24AEa48C422f819c5c8f933701D',
-    fxPHP: '0x2BFD80c4E72164F62515850cec591D06AB857c65'
-  }
+  tokens
 }
 
 export default addresses

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,12 +21,12 @@ export type AddressCollection = {
     router: string
     zap: string
     libraries?: {
-      curves?: string,
-      orchestrator?: string,
-      proportionalLiquidity?: string,
-      swaps?: string,
-      viewLiquidity?: string
-    },
+      curves: string
+      orchestrator: string
+      proportionalLiquidity: string
+      swaps: string
+      viewLiquidity: string
+    }
     curves: {
       enabled: string[]
       disabled: string[]

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,9 @@
+type Pool = {
+  address: string
+  poolId: string
+  assets: string[]
+}
+
 export type AddressCollection = {
   protocol: {
     RNBW: string
@@ -29,11 +35,14 @@ export type AddressCollection = {
   ammV2: {
     vault: string
     pools: {
-      enabled: string[]
-      disabled: string[]
+      genesis: Pool[]
+      enabled: Pool[]
+      disabled: Pool[]
     }
   }
   tokens: {
+    wETH?: string
+    wBTC?: string
     USDC?: string
     EURS?: string
     XSGD?: string


### PR DESCRIPTION
- Added mock token addresses for kovan & rinkeby (used in amm-v2 pools)
- Updated amm-v2 pools struct to include the tokens for each pool along with poolId
  - these additional props is needed on FE swap page for figuring out the swap route